### PR TITLE
Configure MLflow tracking before model load

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 
+import mlflow
 from fastapi import FastAPI, Response
 from prometheus_client import generate_latest
 from starlette.middleware.cors import CORSMiddleware
@@ -53,6 +54,7 @@ async def lifespan(app: FastAPI):
         git_sha=settings.GIT_SHA,
         build_time=settings.BUILD_TIME,
     )
+    mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
 
     loaded_bundles = _load_models()
     if len(loaded_bundles) == len(MODELS_TO_LOAD):


### PR DESCRIPTION
## Summary
- set MLflow tracking URI at app startup so all model operations use the configured server
- import mlflow in main application module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c5e788604832d9efd03303f908f9f