### PR TITLE
feat: support stage alias in model registry

### DIFF
--- a/app/models/registry.py
+++ b/app/models/registry.py
@@ -40,7 +40,7 @@ class ModelInfo(BaseModel):
 
     name: str
     version: str
-    stage: ModelStage
+    stage: ModelStage = Field(alias="current_stage")
     run_id: str
     source_uri: str = Field(..., alias="source")
     last_updated_timestamp: int
@@ -105,7 +105,7 @@ class MlflowModelSelector:
                     alias=champion_alias,
                     version=champion_version.version,
                 )
-                return ModelInfo.model_validate(champion_version)
+                return ModelInfo.model_validate(champion_version.to_dictionary())
         except mlflow.exceptions.RestException as e:
             if e.error_code == "RESOURCE_DOES_NOT_EXIST":
                 logger.debug("No champion alias found for model", model_name=model_name)
@@ -140,7 +140,7 @@ class MlflowModelSelector:
                     stage=stage.value,
                     version=selected_version.version,
                 )
-                return ModelInfo.model_validate(selected_version)
+                return ModelInfo.model_validate(selected_version.to_dictionary())
 
         logger.warning(
             "Could not select a model version based on any rule", model_name=model_name


### PR DESCRIPTION
## Summary
- allow ModelInfo.stage to parse MLflow's `current_stage`
- validate ModelInfo from dictionary representation of `ModelVersion`

## Testing
- `ruff check app/models/registry.py`
- `pytest -q`
- `uvicorn app.main:app --port 8000` *(fails: Registered Model with name=FraudDetector-lightgbm not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4dbeec4832d84b273636def88f5