### PR TITLE
Silence model field warnings

### DIFF
--- a/app/schemas/predict.py
+++ b/app/schemas/predict.py
@@ -76,7 +76,7 @@ class PredictRequest(BaseModel):
 
 # ---- Response models ----
 class PredictionMeta(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
     model_name: str
     model_version: str


### PR DESCRIPTION
## Summary
- allow model-prefixed fields in `PredictionMeta` by disabling protected namespace warnings

## Testing
- `pytest -q`
- `python -W default - <<'PY'
import app.schemas.predict
PY`


------
https://chatgpt.com/codex/tasks/task_e_689cade726a0832db312e8a9577eb2ec