### PR TITLE
Support ModelVersion without to_dict in registry

### DIFF
--- a/app/models/registry.py
+++ b/app/models/registry.py
@@ -87,7 +87,16 @@ class MlflowModelSelector:
         try:
             return version.to_dict()
         except AttributeError:
-            return vars(version)
+            attrs = {k.lstrip("_"): v for k, v in vars(version).items()}
+            keys = {
+                "name",
+                "version",
+                "current_stage",
+                "run_id",
+                "source",
+                "last_updated_timestamp",
+            }
+            return {k: attrs.get(k) for k in keys}
 
     def select_model_version(
         self, model_name: str, champion_alias: str = "champion"

--- a/tests/unit/test_registry_model_version.py
+++ b/tests/unit/test_registry_model_version.py
@@ -1,0 +1,24 @@
+from app.models.registry import MlflowModelSelector, ModelInfo, ModelStage
+
+
+class DummyModelVersion:
+    def __init__(self):
+        self._name = "test-model"
+        self._version = "1"
+        self._current_stage = "Staging"
+        self._run_id = "run-123"
+        self._source = "s3://models/test-model"
+        self._last_updated_timestamp = 1716239029
+
+
+def test_model_info_validation_without_to_dict():
+    selector = MlflowModelSelector()
+    dummy = DummyModelVersion()
+    version_dict = selector._model_version_to_dict(dummy)
+    info = ModelInfo.model_validate(version_dict)
+    assert info.name == "test-model"
+    assert info.version == "1"
+    assert info.stage == ModelStage.STAGING
+    assert info.run_id == "run-123"
+    assert info.source_uri == "s3://models/test-model"
+    assert info.last_updated_timestamp == 1716239029


### PR DESCRIPTION
## Summary
- Strip leading underscores from ModelVersion attributes when `to_dict` is unavailable
- Add unit test to validate `ModelInfo` parsing from ModelVersion without `to_dict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb27e4254832d9c7a82e30887eacc