### PR TITLE
feat: allow compatible version validation

### DIFF
--- a/app/services/validator.py
+++ b/app/services/validator.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from app.core.config import settings
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -15,14 +16,9 @@ logger = get_logger(__name__)
 # --- Configuration ---
 
 # Rules: library -> "exact" or "compatible"
-VALIDATION_RULES: dict[str, Literal["exact", "compatible"]] = {
-    "scikit-learn": "exact",
-    "xgboost": "exact",
-    "lightgbm": "exact",
-    "pandas": "compatible",
-    "numpy": "compatible",
-    "mlflow": "compatible",
-}
+VALIDATION_RULES: dict[str, Literal["exact", "compatible"]] = (
+    settings.DEPENDENCY_VALIDATION_RULES
+)
 
 # --- Schemas & Exceptions ---
 

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -50,7 +50,7 @@ def create_mock_model_files(tmp_path, conda_deps=None, mlmodel_flavors=None):
 
 
 def test_validator_sklearn_mismatch(validator, tmp_path, mock_mlflow_artifacts):
-    """Test that an exact mismatch for scikit-learn raises an error."""
+    """Test that a minor-version mismatch for scikit-learn raises an error."""
     create_mock_model_files(tmp_path)
 
     mock_versions = {
@@ -73,7 +73,7 @@ def test_validator_sklearn_mismatch(validator, tmp_path, mock_mlflow_artifacts):
         assert error.library == "scikit-learn"
         assert error.required == "==1.4.2"
         assert error.running == "1.5.0"
-        assert error.policy == "exact"
+        assert error.policy == "compatible"
 
 
 def test_validator_pandas_compatible(validator, tmp_path, mock_mlflow_artifacts):


### PR DESCRIPTION
## Summary
- allow validator rules to be configured
- default to minor-version compatible checks for popular ML libs
- adjust unit tests for new compatibility policy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc172ccd0832db9e42df4d5d8c681