### PR TITLE
Resolve mypy typing issues

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -65,7 +65,8 @@ class Settings(BaseSettings):
         cls, v: Any
     ) -> dict[str, Literal["exact", "compatible"]]:
         if isinstance(v, str):
-            return json.loads(v)
+            data = json.loads(v)
+            return cast(dict[str, Literal["exact", "compatible"]], data)
         return cast(dict[str, Literal["exact", "compatible"]], v)
 
 


### PR DESCRIPTION
## Summary
- fix type casting in dependency validation rules
- ensure registry model selection returns typed `ModelInfo`

## Testing
- `ruff check .`
- `mypy app`
- `pytest` *(fails: ModuleNotFoundError: No module named 'mlflow'; ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689cc483f6a8832dbcdd61eb6cf093f3