### PR TITLE
chore: add dependency requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ pydantic-settings = "2.2.1"
 pyyaml = "^6.0.2"
 setuptools = "^80.9.0"
 boto3 = "^1.34.119"
+defusedxml = "0.7.*"
+psutil = "5.9.*"
+imbalanced-learn = "0.13.*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"


### PR DESCRIPTION
## Summary
- include libgomp1 in runtime image so LightGBM can use OpenMP
- add defusedxml, psutil, and imbalanced-learn as project dependencies

## Testing
- `pytest`
- `podman build -t fraud-inference-api:test .` *(fails: creating build container: copying system image ... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cc8f38a00832db9b997fd8377c3ad