### PR TITLE
Use uppercase AS for Docker build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile for fraud detection API
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -33,7 +33,7 @@ COPY app/ ./app/
 # Create directories for model artifacts
 RUN mkdir -p /app/models /app/logs
 
-FROM python:3.11-slim as final
+FROM python:3.11-slim AS final
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary
- Use uppercase `AS` in `FROM` statements for build and final stages in Dockerfile

## Testing
- `docker build -t fraud-inference .` *(fails: Cannot connect to the Docker daemon; daemon startup fails due to iptables permission issues)*

------
https://chatgpt.com/codex/tasks/task_e_689cce4615f8832db8192fe4704180c7