### PR TITLE
fix: silence mypy attr-defined errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,27 +5,31 @@ import types
 if importlib.util.find_spec("mlflow") is None:
     mlflow_module = types.ModuleType("mlflow")
     tracking_module = types.ModuleType("mlflow.tracking")
-    tracking_module.MlflowClient = lambda tracking_uri=None: types.SimpleNamespace()
+    setattr(
+        tracking_module,
+        "MlflowClient",
+        lambda tracking_uri=None: types.SimpleNamespace(),
+    )
 
     artifacts_module = types.ModuleType("mlflow.artifacts")
-    artifacts_module.download_artifacts = lambda artifact_uri=None: None
+    setattr(artifacts_module, "download_artifacts", lambda artifact_uri=None: None)
 
     model_registry_module = types.ModuleType("mlflow.entities.model_registry")
-    model_registry_module.ModelVersion = object
+    setattr(model_registry_module, "ModelVersion", object)
     entities_module = types.ModuleType("mlflow.entities")
-    entities_module.model_registry = model_registry_module
+    setattr(entities_module, "model_registry", model_registry_module)
 
     class RestException(Exception):
         def __init__(self, error_code: str = ""):
             self.error_code = error_code
 
     exceptions_module = types.ModuleType("mlflow.exceptions")
-    exceptions_module.RestException = RestException
+    setattr(exceptions_module, "RestException", RestException)
 
-    mlflow_module.tracking = tracking_module
-    mlflow_module.artifacts = artifacts_module
-    mlflow_module.entities = entities_module
-    mlflow_module.exceptions = exceptions_module
+    setattr(mlflow_module, "tracking", tracking_module)
+    setattr(mlflow_module, "artifacts", artifacts_module)
+    setattr(mlflow_module, "entities", entities_module)
+    setattr(mlflow_module, "exceptions", exceptions_module)
 
     sys.modules["mlflow"] = mlflow_module
     sys.modules["mlflow.tracking"] = tracking_module


### PR DESCRIPTION
## Summary
- fix test mlflow stubs so attributes are added with `setattr`

## Testing
- `poetry run ruff .`
- `poetry run mypy .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cdf76cef4832d95f56b98069b13ad