### PR TITLE
Fix warmup payload typing for mypy

### DIFF
--- a/app/models/loader.py
+++ b/app/models/loader.py
@@ -97,6 +97,7 @@ def _create_warmup_payload(signature: dict, n_rows: int = 1) -> pd.DataFrame:
             name = spec.get("name") or f"f{i}"
             mlt = (spec.get("type") or "string").lower()
 
+        val: int | float | str | bool
         if mlt in ("long", "integer", "int"):
             val = 0
         elif mlt in ("float", "double"):


### PR DESCRIPTION
## Summary
- ensure `_create_warmup_payload` uses properly typed union for warmup values

## Testing
- `poetry run mypy .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d6f2168e8832db6ff57479caec11b